### PR TITLE
Lua + Bugfixes

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -7,6 +7,7 @@ import states.CrashHandlerState;
 import openfl.events.Event;
 import haxe.CallStack;
 import lime.system.System;
+import flixel.util.FlxTimer;
 #if sys
 import sys.io.File;
 import sys.FileSystem;
@@ -23,6 +24,8 @@ using StringTools;
 
 class QMGame extends FlxGame
 {
+	var message:String;
+	var stack:CallStack;
 	public function new(gameWidth = 0, gameHeight = 0, ?initialState:Class<FlxState>, updateFramerate = 60, drawFramerate = 60, skipSplash = false,
 			startFullscreen = false)
 	{
@@ -33,6 +36,8 @@ class QMGame extends FlxGame
 	
 	override function create(_:Event)
 	{
+		message = "";
+		stack = null;
 		try
 		{
 			super.create(_);
@@ -40,7 +45,9 @@ class QMGame extends FlxGame
 		}
 		catch (e)
 		{
-			FlxG.switchState(new CrashHandlerState(e.message, e.stack));
+			new FlxTimer().start(1.0, crashHandler, 1);
+			message = e.message;
+			stack = e.stack;
 		}
 	}
 
@@ -52,7 +59,9 @@ class QMGame extends FlxGame
 		}
 		catch (e)
 		{
-			FlxG.switchState(new CrashHandlerState(e.message, e.stack));
+			new FlxTimer().start(1.0, crashHandler, 1);
+			message = e.message;
+			stack = e.stack;
 		}
 	}
 
@@ -64,10 +73,18 @@ class QMGame extends FlxGame
 		}
 		catch (e)
 		{
+			
+			new FlxTimer().start(1.0, crashHandler, 1);
+			message = e.message;
+			stack = e.stack;
 			trace('got a crash: ${e.message}');
-			FlxG.switchState(new CrashHandlerState(e.message, e.stack));
+			
 		}
 	}
+	function crashHandler(timer:FlxTimer):Void
+		{
+			FlxG.switchState(new CrashHandlerState(message, stack));
+		}
 }
 
 class Main extends Sprite

--- a/source/QLua.hx
+++ b/source/QLua.hx
@@ -1,5 +1,8 @@
 package;
 
+import flixel.FlxState;
+import flixel.util.FlxColor;
+import flixel.FlxG;
 import gameplay.SongState;
 import flixel.tweens.FlxTween;
 import llua.Lua;
@@ -9,7 +12,7 @@ import llua.Convert;
 
 class QLua
 {
-	public var lua:State = null;
+	public static var lua:State = null;
 	public var scriptName:String = '';
 
 	public function new(script:String)
@@ -38,11 +41,83 @@ class QLua
 
 		set('scrollSpeed', Preferences.scrollSpeed);
 		set('downscroll', Preferences.downscroll);
+		set('curBeat', SongState.curBeat);
+		set('curStep', SongState.curStep);
 
 		Lua_helper.add_callback(lua, "strumTween", function(id:Int, variable:String, value:Dynamic, duration:Float, ease:String)
 		{
 			SongState.instance.strumTween(id, variable, value, duration, ease);
 		});
+
+		Lua_helper.add_callback(lua, "cameraFlash", function(color:String, duritation:Float){ //bruhh istg there is a better way to do this
+			if (color == "red" || color == "Red" || color == "RED")
+				FlxG.camera.flash(FlxColor.RED, duritation);
+
+			if (color == "orange" || color == "Orange" || color == "ORANGE")
+				FlxG.camera.flash(FlxColor.ORANGE, duritation);
+
+			if (color == "yellow" || color == "Yellow" || color == "YELLOW")
+				FlxG.camera.flash(FlxColor.YELLOW, duritation);
+
+			if (color == "green" || color == "Green" || color == "GREEN")
+				FlxG.camera.flash(FlxColor.GREEN, duritation);
+
+			if (color == "lime" || color == "Lime" || color == "LIME")
+				FlxG.camera.flash(FlxColor.LIME, duritation);
+
+			if (color == "cyan" || color == "Cyan" || color == "CYAN")
+				FlxG.camera.flash(FlxColor.CYAN, duritation);
+
+			if (color == "blue" || color == "Blue" || color == "BLUE")
+				FlxG.camera.flash(FlxColor.BLUE, duritation);
+
+			if (color == "purple" || color == "Purple" || color == "PURPLE")
+				FlxG.camera.flash(FlxColor.PURPLE, duritation);
+
+			if (color == "magenta" || color == "Magenta" || color == "MAGENTA")
+				FlxG.camera.flash(FlxColor.MAGENTA, duritation);
+
+			if (color == "pink" || color == "Pink" || color == "PINK")
+				FlxG.camera.flash(FlxColor.PINK, duritation);
+
+			if (color == "white" || color == "White" || color == "WHITE")
+				FlxG.camera.flash(FlxColor.WHITE, duritation);
+
+			if (color == "gray" || color == "Gray" || color == "GRAY")
+				FlxG.camera.flash(FlxColor.GRAY, duritation);
+
+			if (color == "brown" || color == "Brown" || color == "BROWN")
+				FlxG.camera.flash(FlxColor.BROWN, duritation);
+
+			if (color == "black" || color == "Black" || color == "BLACK")
+				FlxG.camera.flash(FlxColor.BLACK, duritation);
+		});
+		call('create', []);
+	}
+
+	/*public static function beatHit() fix one day.
+		{
+			call('beatHit', []);
+		}*/
+
+	static public function call(theFunction:String, theArguments:Array<Dynamic>):Dynamic { 
+		Lua.getglobal(lua, theFunction);
+		Lua.call(lua, theArguments.length, 1);
+		return 0;
+	}
+
+	static function typeToString(type:Int):String {
+		#if LUA_ALLOWED
+		switch(type) {
+			case Lua.LUA_TBOOLEAN: return "boolean";
+			case Lua.LUA_TNUMBER: return "number";
+			case Lua.LUA_TSTRING: return "string";
+			case Lua.LUA_TTABLE: return "table";
+			case Lua.LUA_TFUNCTION: return "function";
+		}
+		if (type <= Lua.LUA_TNIL) return "nil";
+		#end
+		return "unknown";
 	}
 
 	public function set(variable:String, data:Dynamic)

--- a/source/states/CrashHandlerState.hx
+++ b/source/states/CrashHandlerState.hx
@@ -32,6 +32,8 @@ class CrashHandlerState extends FlxState
 	function constructCallStack():String
 	{
 		var callStackText:String = "";
+		if (callStack != null)
+			{
 		for (stackItem in callStack)
 		{
 			switch (stackItem)
@@ -44,6 +46,9 @@ class CrashHandlerState extends FlxState
 			Sys.println(stackItem);
 		}
 		return callStackText;
+	}else{
+		return "";
+	}
 	}
 
 	override function create()
@@ -80,8 +85,8 @@ class CrashHandlerState extends FlxState
 		if (callStackMessage.text == 'Call Stack:\n')
 		{
 			remove(callStackMessage);
-			errorMessage.x = 0;
-			errorMessage.fieldWidth = FlxG.width;
+			errorMessage.fieldWidth = 1000;
+			errorMessage.screenCenter(X);
 		}
 
 		new FlxTimer().start(1, function(tmr)
@@ -93,7 +98,12 @@ class CrashHandlerState extends FlxState
 				case 2:
 					FlxTween.tween(error, {y: 10, alpha: 1}, 1, {ease: FlxEase.cubeOut});
 				case 1:
+					if (errorMessage.fieldWidth != 1000)
+						{
 					FlxTween.tween(errorMessage, {y: FlxG.height / 2, alpha: 1}, 1, {ease: FlxEase.cubeOut});
+						}else{
+							FlxTween.tween(errorMessage, {y: (FlxG.height - errorMessage.height) / 2, alpha: 1}, 1, {ease: FlxEase.cubeOut});
+						}
 					FlxTween.tween(callStackMessage, {y: FlxG.height / 2 - callStackMessage.height / 2, alpha: 1}, 1, {ease: FlxEase.cubeOut});
 					FlxTween.tween(buttonMsg, {alpha: 1}, 1, {ease: FlxEase.cubeOut});
 			}

--- a/source/states/songselect/SongSelectState.hx
+++ b/source/states/songselect/SongSelectState.hx
@@ -53,6 +53,7 @@ class SongSelectState extends FlxState
 		songNameList = QMAssets.FNFreadAllCharts();
 		if (songNameList == null)
 		{
+			FlxG.switchState(new states.CrashHandlerState("You don't have any songs added. To add a new song or multiple songs, In the games main folder, add a folder called mods. Then make a folder named the type of mod you want to add. For a starter pack, go to (link here) For more info on how to install mods, read this (article?? idfk) here: (link here)", null));
 			trace("No songs!");
 			var noSongs = new SongSelectBox(0, "No songs!", 0);
 			add(noSongs);


### PR DESCRIPTION
### _Lua:_
Lua is now usable. in your mod (mods/fnf/randomSong), make a folder called lua (mods/fnf/randomSong/lua). in there, add lua files with the script. Example script:

```
function create()
    print("test2")
    cameraFlash("white", 5)
end
```

_(NOTE: the strumTween doesnt work, and you can have multiple lua files.)_

### _Bugfixes:_

- Accuracy no longer goes below 0%
- The health text no longer stays on-screen after death
- when you have no songs, it gives you a soft crash telling you how to fix it instead of giving a error.